### PR TITLE
fix: add white background

### DIFF
--- a/lib/phx_diff_web/components/layouts/root.html.heex
+++ b/lib/phx_diff_web/components/layouts/root.html.heex
@@ -25,7 +25,7 @@
     </script>
   </head>
 
-  <body class="min-h-screen flex flex-col">
+  <body class="min-h-screen bg-white flex flex-col">
     <nav role="navigation">
       <div class="p-4 flex text-brand justify-between items-center">
         <a class="text-2xl font-bold" href="/">PhoenixDiff</a>


### PR DESCRIPTION
Hi, in some browsers, when a background color is not explicitly defined, the website is a little bit broken.

## Example in Zen Browser

| Before | After |
|:-:|:-:|
| ![image](https://github.com/user-attachments/assets/a9299c74-044c-4726-970f-d9d0338c2ae6) | ![image](https://github.com/user-attachments/assets/5c8f44f3-7b53-4013-9873-caf555dd7a8a) |

Thank you for this project btw! :bow: 