### PR TITLE
Specify prefix for GitDiff

### DIFF
--- a/lib/phx_diff/diffs/diff_engine.ex
+++ b/lib/phx_diff/diffs/diff_engine.ex
@@ -25,6 +25,8 @@ defmodule PhxDiff.Diffs.DiffEngine do
            "diff",
            "--no-index",
            "--no-color",
+           "--src-prefix=a/",
+           "--dst-prefix=b/",
            source_path,
            target_path
          ]) do


### PR DESCRIPTION
Generate diffs with prefixes expected by GitDiff, ensuring consistency regardless of local Git configuration.